### PR TITLE
Add CODEOWNERS as @embulk/core-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@embulk/core-team


### PR DESCRIPTION
This is the very initial version of our "nightly" regression tests for typical use-cases. Starting from testing :

* a fixed version of `embulk-input-postgresql`
* with a fixed version of Embulk
* on multiple versions of OpenJDK
* to multiple version of PostgreSQL.

It is intended to extend for other plugins, other environments, more test cases, automated upgrades, and else...